### PR TITLE
Avatar: Support Cash Effect (501)

### DIFF
--- a/WzComparerR2.Avatar/AvatarCanvas.cs
+++ b/WzComparerR2.Avatar/AvatarCanvas.cs
@@ -18,7 +18,7 @@ namespace WzComparerR2.Avatar
             this.Actions = new List<Action>();
             this.Emotions = new List<string>();
             this.TamingActions = new List<string>();
-            this.Parts = new AvatarPart[18];
+            this.Parts = new AvatarPart[19];
             this.EarType = 0;
             this.WeaponIndex = 0;
         }
@@ -292,6 +292,10 @@ namespace WzComparerR2.Avatar
                     if (Gear.IsWeapon(gearType))
                     {
                         this.Weapon = part;
+                    }
+                    if (part.ItemEff != null)
+                    {
+                        this.Effect = part;
                     }
                     break;
             }
@@ -1282,7 +1286,7 @@ namespace WzComparerR2.Avatar
                     }
                 }
                 //Another
-                for (int i = 4; i < 16; i++)
+                for (int i = 4; i < Parts.Length; i++)
                 {
                     var part = this.Parts[i];
                     ActionFrame CloneAction = bodyAction;
@@ -1683,6 +1687,12 @@ namespace WzComparerR2.Avatar
         {
             get { return this.Parts[17]; }
             set { this.Parts[17] = value; }
+        }
+
+        public AvatarPart Effect
+        {
+            get { return this.Parts[18]; }
+            set { this.Parts[18] = value; }
         }
 
         #endregion

--- a/WzComparerR2.Avatar/AvatarPart.cs
+++ b/WzComparerR2.Avatar/AvatarPart.cs
@@ -37,7 +37,7 @@ namespace WzComparerR2.Avatar
 
         private void LoadInfo()
         {
-            var m = Regex.Match(Node.Text, @"^(\d+)\.img$");
+            var m = Regex.Match(Node.Text, @"^(\d+)(\.img)?$");
             if (m.Success)
             {
                 this.ID = Convert.ToInt32(m.Result("$1"));
@@ -66,6 +66,11 @@ namespace WzComparerR2.Avatar
 
         private void LoadEffectInfo()
         {
+            if (this.Node.Nodes["effect"] != null)
+            {
+                ItemEff = this.Node.Nodes["effect"];
+                return;
+            }
             Wz_Node itemEff = PluginBase.PluginManager.FindWz("Effect\\ItemEff.img");
             if(itemEff == null)
             {

--- a/WzComparerR2.Avatar/Entry.cs
+++ b/WzComparerR2.Avatar/Entry.cs
@@ -26,6 +26,7 @@ namespace WzComparerR2.Avatar
             var tabCtrl = f.GetTabPanel();
             Context.AddTab(f.Text, tabCtrl);
             Context.SelectedNode1Changed += f.OnSelectedNode1Changed;
+            Context.SelectedNode2Changed += f.OnSelectedNode2Changed;
             Context.WzClosing += f.OnWzClosing;
             this.Tab = tabCtrl.TabItem;
         }

--- a/WzComparerR2.Avatar/UI/AvatarForm.cs
+++ b/WzComparerR2.Avatar/UI/AvatarForm.cs
@@ -612,10 +612,13 @@ namespace WzComparerR2.Avatar.UI
                                 {
                                     FrameNode = searchNode.FindNodeByPath("default");
                                 }
-                                eLayer.delays=(FindEffectDelay(FrameNode));
-                                eLayer.currentFrame = 0;
-                                eLayer.animated = false;
-                                effectForm.EffectLayerGroup.Add(part.ID.Value,eLayer);//List Test
+                                if (FrameNode != null)
+                                {
+                                    eLayer.delays=(FindEffectDelay(FrameNode));
+                                    eLayer.currentFrame = 0;
+                                    eLayer.animated = false;
+                                    effectForm.EffectLayerGroup.Add(part.ID.Value,eLayer);//List Test
+                                }
                             }
                         }
                         


### PR DESCRIPTION
안녕하세요. 멋진 기능 개발해주셔서 고맙습니다.

메인 레포지토리에 머지하고 싶었지만 리팩토링에 시간이 다소 걸려서, 일단 중요해 보이는 기능부터 하나 새로 개발하여 PR 드립니다.

개발한 내용은 캐시 이펙트 (`Item\Cash\0501.img` 아래에 있는 아이템들) 지원 입니다. 만들어주신 Effect 부분을 거의 활용했으며, 나머지는 아바타 창에서 Gear가 아닌 Item이 착용될 수 있도록 하는 내용이 주로 들어가 있습니다.

다음은 관련 스크린샷과 내보낸 GIF입니다.

![image](https://user-images.githubusercontent.com/6624567/64921043-07406500-d7f9-11e9-8af7-21fbea2bc1b8.png)

![avatar_walk1_default](https://user-images.githubusercontent.com/6624567/64921046-0ad3ec00-d7f9-11e9-8a9e-f8331ff9ccd6.gif)

\+ 추가로 이 repo는 main branch를 kms-MixEff로 해 놓으시면 더욱 코드 변경점이 잘 드러나겠습니다. 😄

감사합니다. 

박현민 드림